### PR TITLE
Add AI Conference Deadline link to "Resources"

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 ## :paperclip: Resources
 
 - [ICLR 2024 Paper Summaries](https://areganti.notion.site/06f0d4fe46a94d62bff2ae001cfec22c?v=d501ca62e4b745768385d698f173ae14)
+- [AI Conference Deadline](https://www.aiconferenceddl.com/) - A simple AI/ML conference deadline tracker
 
 ---
 


### PR DESCRIPTION
Added a link to [AI Conference Deadline](https://www.aiconferenceddl.com/), a useful AI/ML conference deadline tracker.