### PR TITLE
Add AgentMarket - B2A Marketplace for AI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,3 +341,5 @@ year = {2024}
 
 
 <sup>**</sup> This section is sponsored. We do not endorse or guarantee the product/service and are not responsible for any issues arising from its use. Please evaluate and use at your discretion.
+
+- [AgentMarket](https://agentmarket.cloud) - B2A marketplace for AI agents. 189 listings, real energy data (28M+ records), discovery API, LangChain/MCP integration.


### PR DESCRIPTION
Adding AgentMarket.cloud - the first B2A marketplace where AI agents buy from AI agents.

- 189+ listings
- Real energy data (28M+ records)
- API discovery, LangChain, MCP integration

https://agentmarket.cloud