### PR TITLE
Add AI Job Displacement Tracker to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 ## :paperclip: Resources
 
 - [ICLR 2024 Paper Summaries](https://areganti.notion.site/06f0d4fe46a94d62bff2ae001cfec22c?v=d501ca62e4b745768385d698f173ae14)
+- [AI Job Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) - Structured, source-backed dataset tracking 96 AI-attributed workforce reductions (457K workers affected, 13 countries, 13 sectors). Includes source URLs, attribution tiers, and job functions. Available in JSON/CSV.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the [AI Job Displacement Tracker](https://github.com/noahaust2/ai-displacement-tracker) to the **Resources** section.

This is a structured, source-backed dataset tracking 96 AI-attributed workforce reductions (457K workers affected across 13 countries and 13 sectors). Every entry includes source URLs, attribution tiers, and affected job functions. Available in JSON and CSV formats under CC-BY-4.0.

The dataset is relevant to the generative AI community as it documents the real-world workforce impact of AI/GenAI adoption across industries — useful context for researchers, developers, and policymakers working in the generative AI space.

## Changes

- Added one entry to the "Resources" section in `README.md`, following the existing `- [Title](URL) - Description` format.