### PR TITLE
Add LongTrainer to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 
 #### Comprehensive LLM Code Repositories 
 - [LLM-PlayLab](https://github.com/Sakil786/LLM-PlayLab) This playlab encompasses a multitude of projects crafted through the utilization of Transformer Models
+- [LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer) A production-ready RAG framework built on top of LangChain for multi-tenant memory, tracking, and streaming.
 
 
 ---


### PR DESCRIPTION
Hi there! 👋

I would like to propose adding **[LongTrainer](https://github.com/ENDEVSOLS/Long-Trainer)** to this awesome list. 

### What is LongTrainer?
LongTrainer is a production-ready framework built on top of LangChain. It allows developers to turn their documents into intelligent, multi-tenant chatbots with just a few lines of code. 

### Why is it a good fit here?
It abstracts away the complexities of manually wiring together chains, memory, tools, and retrievers by offering batteries-included features for production:
- **Multi-bot architecture:** Built-in multi-tenant isolation for managing separate bots effortlessly.
- **Persistent Memory:** Ready-to-use MongoDB-backed, encrypted chat history.
- **Agentic Capabilities:** Supports both standard RAG pipelines and dynamic LangGraph agent tool-calling (web search, custom functions).
- **Extensive Document & Vision Support:** Natively parses PDFs, databases, URLs, and multi-modal images without friction.
- **Streaming:** First-class support for sync and async streaming out of the box.

I believe this will be an extremely valuable, time-saving resource for developers in this community looking to spin up robust GenAI/RAG applications in production quickly.

Thank you for your time and for maintaining this awesome list! Let me know if you need me to adjust the formatting to better fit the repository guidelines. 
