### PR TITLE
Add Agentic Engineering Jobs to Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 ## :paperclip: Resources
 
 - [ICLR 2024 Paper Summaries](https://areganti.notion.site/06f0d4fe46a94d62bff2ae001cfec22c?v=d501ca62e4b745768385d698f173ae14)
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Curated job board for engineers building agentic systems (RAG pipelines, AI agents, LLM-powered products, agent orchestration). Includes an interview guide and salary data for AI engineering roles. Free to post, free to browse.
 
 ---
 


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com to the Resources section.

It's a curated job board and career resource specifically for engineers building agentic systems — RAG pipelines, AI agents, LLM-powered products, and agent orchestration. Beyond the listings themselves, it includes:

- An [AI engineering interview guide](https://agentic-engineering-jobs.com/hire/interview-guide)
- [Salary data](https://agentic-engineering-jobs.com/ai-native-engineer-salaries) aggregated from 500+ active listings
- A [definitional page](https://agentic-engineering-jobs.com/what-is-ai-native-engineering) on AI-native / agentic engineering as a discipline

500+ active listings, free to post for companies, free to browse for job seekers, no paywall.

Felt like a natural fit alongside the existing Resources entry given the educational/career-prep focus of this guide. Happy to move it to Interview Prep or adjust description if you'd prefer.