### PR TITLE
Add Consensus Engine — multi-LLM consensus tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Happy Learning!
 ---
 ## :star: Top AI Tools List
 
+- [Consensus Engine](https://github.com/MICONNM/consensus-engine-py) - Ask one question to 11 frontier LLMs in parallel, get a synthesized consensus answer with confidence score. Open-source Python SDK + free public API.
 Discover our favorite AI tools spanning every layer of AI application development. Click [here](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/main/resources/our_favourite_ai_tools.md) to learn more.
 
 ---


### PR DESCRIPTION
Hi! Adding [Consensus Engine](https://github.com/MICONNM/consensus-engine-py) to this list.

**What it does**: Sends the same question to 11 frontier LLMs (Llama 4, Mistral 675B, Qwen 3.5 397B, Qwen3-Coder 480B, Llama 3.1 405B, Nemotron Ultra 253B, GLM-5.1, DeepSeek V4 Pro, Kimi K2.5, MiniMax M2.7, Phi-4) in parallel and synthesizes a consensus answer with a confidence score.

**Why it fits**: A growing problem with LLM tooling is single-model dependence. Consensus Engine is the open-source primitive for "ask N models, blend the answers" — useful for researchers benchmarking models, devs hedging hallucination risk, and teams building agent systems.

- Open-source (Python SDK): `pip install consensus-engine` (or clone)
- Free public arena: https://api.yanmiayn.com (10 questions/day per IP, no signup)
- Apache-2.0 licensed

I followed the existing list's alphabetical/section conventions; happy to adjust if a different placement is preferred. Thanks for maintaining this list!
