### PR TITLE
Add APort Agent Guardrails to security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,3 +347,5 @@ year = {2024}
 ## Security & Safety Tools
 
 - **[OWASP Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard)** - Official OWASP reference implementation for AI agent memory poisoning defense (ASI06 from OWASP Top 10 for Agentic AI Systems). Provides pre-write scanning, pre-read validation, and audit logging for agent memory.
+- **[APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails)** - Open-source runtime guardrails for AI agents that enforce pre-action authorization and policy checks before tool calls.
+


### PR DESCRIPTION
## Summary
- Adds APort Agent Guardrails to the Security & Safety Tools section.
- Uses the official open-source repository link and a concise description focused on pre-action authorization for AI agent tool calls.

Context: submitted for aporthq/aport-integrations#19.

AI-assisted; reviewed before submission.