### PR TITLE
Add guard-eval-harness under AI Observability and Monitoring (community suggestion)

### DIFF
--- a/resources/our_favourite_ai_tools.md
+++ b/resources/our_favourite_ai_tools.md
@@ -117,6 +117,18 @@ With Opik, you can log, view, and evaluate your LLM (Large Language Model) trace
 - [Opik Documentation](https://www.comet.ml/docs/opik/quickstart)
 - [YouTube: Introducing Opik: Open-Source LLM Evaluation from Comet](https://www.youtube.com/watch?v=B4oboG62lyA)
 
+### guard-eval-harness
+
+**guard-eval-harness (`geh`)** is an MIT-licensed CLI for benchmarking the LLM safety guardrail and moderation classifier models that wrap production LLM applications — Llama Guard 3, ShieldGemma, WildGuard, Qwen3-Guard, OpenAI Moderation, and others — against 80+ public safety datasets (XSTest, ToxicChat, HarmBench, BeaverTails, WildGuardMix, and more).
+
+[Explore guard-eval-harness](https://github.com/Virtue-Research/guard-eval-harness)
+
+It standardizes both sides of the safety-classifier comparison: dataset loading (with documented label-normalization mappings) and metric shape (per-threshold F1/AUROC, FPR/FNR tradeoff curves), with pluggable adapters for HuggingFace, vLLM (offline + HTTP), OpenAI, Anthropic, and generic HTTP endpoints. Useful when teams need to objectively decide which safety classifier to deploy in front of an LLM product, rather than relying on the slightly-different evaluation slice each model ships with in its release card.
+
+**Getting Started with guard-eval-harness:**
+- [Repository and Quickstart](https://github.com/Virtue-Research/guard-eval-harness#readme)
+- [Documentation](https://virtue-research.github.io/guard-eval-harness/)
+
 
 
 ---


### PR DESCRIPTION
Hi @aishwaryanr — thanks for maintaining this guide, the curated tool list and the free GenAI courses have been a big help to people on our team learning the space.

Submitting a community suggestion to add [`guard-eval-harness`](https://github.com/Virtue-Research/guard-eval-harness) (`geh`) to **resources/our_favourite_ai_tools.md** under the existing **AI Observability and Monitoring** category, alongside Comet and Opik.

### What it is

`geh` is an MIT-licensed CLI for benchmarking the LLM safety guardrail and moderation classifier models that wrap production LLM applications — Llama Guard 3, ShieldGemma, WildGuard, Qwen3-Guard, OpenAI Moderation, and others — against 80+ public safety datasets.

```bash
pip install geh
geh run --pack core --model hf --model-name meta-llama/Llama-Guard-3-8B
```

It sits in the same evaluation/monitoring layer as Comet/Opik but is focused specifically on the **safety classifier** decision teams have to make when shipping LLM products: "which guard model should I deploy in front of my LLM?" Today that decision is multi-week ad-hoc work because every guard model is benchmarked on a different evaluation slice. `geh` standardizes the comparison so it's a one-line CLI.

### Entry format

I matched the existing editorial style (`### Name` → bold name + description + Explore link + secondary paragraph + **Getting Started** bullet list). Single-file diff to `resources/our_favourite_ai_tools.md`. README.md is untouched.

### Honest framing

I noticed the main README's **Security & Safety Tools** section has a "sponsored" disclaimer — I deliberately did NOT submit there. This PR is a community suggestion for the curated tools list, not a request for sponsored placement. Totally understand if curated editorial selections are reserved for tools you've personally evaluated; in that case feel free to close with no offense taken.

Thanks for the work either way.