### PR TITLE
Add Spanlens to AI Observability and Monitoring section

### DIFF
--- a/resources/our_favourite_ai_tools.md
+++ b/resources/our_favourite_ai_tools.md
@@ -121,6 +121,20 @@ With Opik, you can log, view, and evaluate your LLM (Large Language Model) trace
 
 ---
 
+### Spanlens
+
+**Spanlens** is an open-source (MIT) LLM observability platform built for application developers. The integration is a one-line baseURL swap or a drop-in SDK that captures every OpenAI, Anthropic, or Gemini call with full body, model, tokens, cost, latency, and trace context. No callback handler required for code paths you do not own (third-party libraries, background workers, MCP servers).
+
+Spanlens differentiates with Critical Path agent tracing (highlights the longest dependency chain in multi-step agents), Prompt A/B with Welch t-test for statistical significance on latency and cost, a model-swap savings recommender that surfaces concrete dollar savings, and built-in PII and prompt-injection detection. The entire stack is MIT licensed with no enterprise-edition folder, and self-host runs from one Docker Compose file.
+
+**Getting Started with Spanlens:**  
+- [Spanlens Documentation](https://www.spanlens.io/docs/quick-start)
+- [GitHub: spanlens/Spanlens](https://github.com/spanlens/Spanlens)
+
+
+
+---
+
 # AI-Powered Tools  
 *Products designed to streamline the AI development lifecycle, from prototyping to debugging and performance tuning.*
 


### PR DESCRIPTION
Adds Spanlens to the **AI Observability and Monitoring** section of `resources/our_favourite_ai_tools.md`, alongside Comet and Opik.

**What it is:** Spanlens is an open-source (MIT) LLM observability platform built for application developers. The integration is a one-line baseURL swap or a drop-in SDK that captures every OpenAI, Anthropic, or Gemini call with full body, model, tokens, cost, latency, and trace context.

**Why it fits the section:** The section already lists Comet and Opik, both observability/monitoring platforms. Spanlens is in the same category and differentiates on:

- **Proxy-first install** — one-line baseURL swap, no callback handler required for code paths you do not own (third-party libraries, background workers, MCP servers).
- **Critical Path agent tracing** — automatically highlights the longest dependency chain in multi-step agents, the real bottleneck rather than just the longest span.
- **Prompt A/B with Welch t-test** — statistical significance on latency and cost, plus a z-test on error rate, surfaced in the dashboard rather than left as BYO analysis.
- **Model-swap savings recommender** — surfaces concrete dollar savings ("swap these gpt-4o classification calls to gpt-4o-mini for $412/mo saved") with the evidence.
- **Fully MIT licensed** — no enterprise-edition folder, no SCIM/audit-logs/RBAC gated behind a commercial license.
- **Self-host with one Docker Compose file.**

**Links:**
- Repo: https://github.com/spanlens/Spanlens
- Hosted SaaS: https://www.spanlens.io
- Quick-start docs: https://www.spanlens.io/docs/quick-start

Followed the existing entry format (heading + 1-2 paragraphs + Getting Started bullet list). Happy to shorten, split, or adjust the section heading style if it would fit better.