### PR TITLE
Add LLM Flashcards under Interview Prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 6. Generative Models Foundations
 7. Latest Research Trends
 
+#### Study Materials:
+
+- [LLM Flashcards](https://github.com/llmsresearch/llm-flashcards) - Hand-drawn flashcards covering transformer internals, attention, KV cache, RAG, fine-tuning, agents, and inference. Useful for visual revision before LLM and ML engineering interview rounds.
+
 #### GenAI System Design (Coming Soon):
 
 1. Designing an LLM-Powered Search Engine


### PR DESCRIPTION
Adding [LLM Flashcards](https://github.com/llmsresearch/llm-flashcards) under Interview Prep, as a new "Study Materials" subsection (since the existing subsections are for question collections and system design, neither of which fits a flashcard deck).

Hand-drawn flashcards covering core LLM topics: transformer internals, attention, KV cache, RAG, fine-tuning, agents, inference. Useful for visual interview prep and quick revision before ML and AI engineering rounds. The repo has free sample cards; they are part of a 180-card deck I draw at LLMs Research. PDF and Anki formats.

Happy to adjust placement or wording (or drop the new subsection and place it under Resources instead) if there is a better fit.