### PR TITLE
Add AiToolsObserver to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 
 ## :paperclip: Resources
 
+- [AiToolsObserver](https://aitoolsobserver.com/) - AI discovery and intelligence platform for comparing AI tools, following industry trends, and exploring practical use cases.
 - [ICLR 2024 Paper Summaries](https://areganti.notion.site/06f0d4fe46a94d62bff2ae001cfec22c?v=d501ca62e4b745768385d698f173ae14)
 
 ---


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to the Resources section.

AiToolsObserver is an AI discovery and intelligence platform for comparing AI tools, following industry trends, and exploring practical use cases.

## Disclosure

I am affiliated with AiToolsObserver. I used the broader Resources section rather than presenting it as one of the maintainer's personal favorite development tools.

## Validation

- Confirmed the website is live
- Checked that the URL is not already listed
- Added one concise resource entry