### PR TITLE
Add ClaudeCodeManual to Agents courses — free Claude Code Workflow course

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Engineering](https://github.com/aishwaryanr/awesome-generative-ai-guide/blob/mai
 11. [Multi-Agent Systems with AutoGen](https://www.manning.com/books/multi-agent-systems-with-autogen-cx) by Victor Dibia [Book]
 12. [Large Language Model Agents MOOC, Fall 2024](https://llmagents-learning.org/f24) by Dawn Song & Xinyun Chen – A comprehensive course covering foundational and advanced topics on LLM agents.
 13. [CS294/194-196 Large Language Model Agents](https://rdi.berkeley.edu/llm-agents/f24) by UC Berkeley
+14. [Multi-Agent Orchestration with Claude Code](https://github.com/NickScherbakov/ClaudeCodeManual) by NickScherbakov — Free 15-chapter browser-based course on the Workflow tool: pipeline() vs parallel(), loop-until-dry, adversarial verify, budget-aware loops. 14 hands-on labs, no install.
 
 
 


### PR DESCRIPTION
## What this adds

Proposing to add **[ClaudeCodeManual](https://github.com/NickScherbakov/ClaudeCodeManual)** as item 14 in the Agents courses list.

**Suggested entry:**
```
14. [Multi-Agent Orchestration with Claude Code](https://github.com/NickScherbakov/ClaudeCodeManual) by NickScherbakov — Free 15-chapter browser-based course on the Workflow tool: pipeline() vs parallel(), loop-until-dry, adversarial verify, budget-aware loops. 14 hands-on labs, no install.
```

**Why it fits the Agents section:**
The course teaches the Workflow tool — Claude Code's built-in multi-agent orchestration engine. Students build and run real multi-agent workflows with `pipeline()`, `parallel()`, schema-forced structured output, adversarial verification patterns, and budget-aware loops.

It's the practical counterpart to the academic courses already listed (AutoGen, LangGraph, crewAI, UC Berkeley LLM Agents) — focused on Claude Code specifically rather than a general framework.

**Format:** Single-page web app, open `web/index.html` directly in any browser — no install, no signup. Content in Russian (first comprehensive Russian-language resource on Claude Code); code examples are language-agnostic.

GitHub: https://github.com/NickScherbakov/ClaudeCodeManual