### PR TITLE
Add DeepSeek Harness Handbook to the harness engineering path

### DIFF
--- a/paths/harness-engineering.md
+++ b/paths/harness-engineering.md
@@ -34,6 +34,7 @@ The pieces of a harness, one at a time. All from the [Agentic AI Crash Course](.
 - **Memory** → [part 7](../free_courses/agentic_ai_crash_course/part7_memory_in_agents.md) ⭐
 - **MCP** → [part 5](../free_courses/agentic_ai_crash_course/part5_what_is_mcp_and_why_care.md) ⭐ and Anthropic's **[Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol)** 🌐 🎥
 - **Multi-agent and sub-agents** → [part 8](../free_courses/agentic_ai_crash_course/part8_multi_agent_systems.md) ⭐
+- **[DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook)** 🌐 📖: a source-backed field guide to one composable agent runtime, connecting the loop, tools, MCP, subagents, sessions, approval, sandboxing, and production checks.
 
 ## 4. Evaluate and ship the harness
 


### PR DESCRIPTION
Adds one external reading to **Assemble a harness (builder skill)**.

The linked Apache-2.0 handbook provides a concrete, source-backed runtime study that connects the exact components introduced by this path: the agent loop, tools, MCP, subagents, durable sessions, approval, sandboxing, and production verification. It is labeled as an external reading (`🌐 📖`) and does not replace or modify any LevelUp Labs material.

The change is intentionally limited to one neutral entry in `paths/harness-engineering.md`.