### PR TITLE
Add agent-qa to favorite AI tools

### DIFF
--- a/resources/our_favourite_ai_tools.md
+++ b/resources/our_favourite_ai_tools.md
@@ -124,6 +124,19 @@ With Opik, you can log, view, and evaluate your LLM (Large Language Model) trace
 # AI-Powered Tools  
 *Products designed to streamline the AI development lifecycle, from prototyping to debugging and performance tuning.*
 
+## agent-qa
+
+**agent-qa** is an open-source self-improving QA agent for software teams. It executes natural-language tests across web and mobile applications, re-observes the interface and tries another path when an interaction fails, and uses execution memory to improve future runs.
+
+[Explore agent-qa on GitHub](https://github.com/vostride/agent-qa)
+
+The project provides a dashboard and CLI for developers, plus an MCP server and skills for coding agents. It supports OpenAI- and Anthropic-compatible endpoints, Gemini, local models, Codex, and Claude Code authentication.
+
+**Getting Started with agent-qa:**
+
+- [Documentation](https://vostride.com/docs/agent-qa)
+- [Quickstart](https://vostride.com/docs/agent-qa/quickstart)
+
 ## Vercel v0
 
 **Vercel v0** is an experimental, AI-enhanced version of Vercel's deployment platform, tailored specifically for developers working on AI-driven applications. It integrates state-of-the-art performance tuning and debugging tools into the development workflow, allowing developers to deploy applications with optimal speed and efficiency.  


### PR DESCRIPTION
## Summary

Adds agent-qa to resources/our_favourite_ai_tools.md under AI-Powered Tools.

agent-qa is an source-available self-improving QA agent for software teams with 764 GitHub stars. The new entry covers its natural-language web and mobile testing, self-healing UI execution, persistent memory, dashboard and CLI, MCP and coding-agent integrations, model flexibility, documentation, and quickstart.

Both documentation links and the canonical GitHub link were verified live.

License note: Agent QA's current FSL-1.1-ALv2 release is source-available rather than OSI open source and converts to Apache-2.0 after two years.

Disclosure: I am affiliated with Agent QA and Vostride.